### PR TITLE
Optional rate limit

### DIFF
--- a/chwrapper/services/base.py
+++ b/chwrapper/services/base.py
@@ -22,7 +22,6 @@
 
 
 from datetime import datetime
-from functools import wraps
 from time import sleep
 import os
 import requests
@@ -30,33 +29,41 @@ import requests
 from .. import __version__
 
 
+class RateLimitAdapter(requests.adapters.HTTPAdapter):
+
+    def __init__(self, **kwargs):
+        super(RateLimitAdapter, self).__init__(**kwargs)
+
+    def rate_limit(self, resp):
+        if resp.headers.get('X-Ratelimit-Remain', '0') == '0':
+            try:
+                timestamp = int(resp.headers['X-Ratelimit-Reset'])
+            except KeyError as e:
+                msg = 'No X-Ratelimit-Reset Header in response'
+                raise KeyError(msg) from e
+
+            reset_dt = datetime.utcfromtimestamp(timestamp)
+            td = reset_dt - datetime.utcnow()
+
+            try:
+                sleep(td.total_seconds() + 1)
+            except ValueError as e:
+                msg = "X-Rate-Limit-Reset time is negative"
+                raise ValueError(msg) from e
+        return resp
+
+    def build_response(self, req, resp):
+        resp = super(RateLimitAdapter, self).build_response(req, resp)
+        self.rate_limit(resp)
+        return resp
+
+
 class Service(object):
 
     def __init__(self):
         self._BASE_URI = "https://api.companieshouse.gov.uk/"
         self._DOCUMENT_URI = "https://document-api.companieshouse.gov.uk/"
-
-    @classmethod
-    def rate_limit(cls, func):
-        """Rate limit a function using the headers returned by the API."""
-        @wraps(func)
-        def wrapper(*args, **kwargs):
-            ret = func(*args, **kwargs)
-            if ret.headers.get('X-Ratelimit-Remain', '0') == '0':
-                try:
-                    timestamp = int(ret.headers['X-Ratelimit-Reset'])
-                except KeyError as e:
-                    msg = 'No X-Ratelimit-Reset Header in response'
-                    raise KeyError(msg) from e
-                reset_dt = datetime.utcfromtimestamp(timestamp)
-                td = reset_dt - datetime.utcnow()
-                try:
-                    sleep(td.total_seconds() + 1)
-                except ValueError as e:
-                    msg = "X-Rate-Limit-Reset time is negative"
-                    raise ValueError(msg) from e
-            return ret
-        return wrapper
+        self._ignore_codes = []
 
     def get_session(self, token=None, env=None):
         access_token = (
@@ -79,9 +86,12 @@ class Service(object):
         """A product token for use in User-Agent headers."""
         return 'chwrapper/{0}'.format(__version__)
 
-    def handle_http_error(self, response, custom_messages={},
+    def handle_http_error(self, response, ignore=[], custom_messages={},
                           raise_for_status=True):
-        if response.status_code in custom_messages.keys():
+        status = response.status_code
+        if status in ignore or status in self._ignore_codes:
+            return None
+        elif response.status_code in custom_messages.keys():
             raise requests.exceptions.HTTPError(
                 custom_messages[response.status_code])
         elif raise_for_status:

--- a/chwrapper/services/base.py
+++ b/chwrapper/services/base.py
@@ -65,12 +65,15 @@ class Service(object):
         self._DOCUMENT_URI = "https://document-api.companieshouse.gov.uk/"
         self._ignore_codes = []
 
-    def get_session(self, token=None, env=None):
+    def get_session(self, access_token=None, env=None, rate_limit=True):
         access_token = (
-            token or
+            access_token or
             (env or os.environ).get('CompaniesHouseKey') or
             (env or os.environ).get('COMPANIES_HOUSE_KEY'))
         session = requests.Session()
+
+        if rate_limit:
+            session.mount(self._BASE_URI, RateLimitAdapter())
 
         session.params.update(access_token=access_token)
 

--- a/chwrapper/services/search.py
+++ b/chwrapper/services/search.py
@@ -30,7 +30,6 @@ This module provides a Search object to query the Companies House API.
 """
 
 from .base import Service
-from .base import RateLimitAdapter
 
 
 class Search(Service):
@@ -45,11 +44,11 @@ class Search(Service):
                 or COMPANIES_HOUSE_KEY environment variables. Defaults to None.
         """
         super(Search, self).__init__()
-        self.session = self.get_session(access_token)
+        self.session = self.get_session(access_token=access_token,
+                                        rate_limit=rate_limit)
         self._ignore_codes = []
         if rate_limit:
             self._ignore_codes.append(429)
-            self.session.mount(self._BASE_URI, RateLimitAdapter())
 
     def search_companies(self, term, **kwargs):
         """Search for companies by name.

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -47,6 +47,7 @@ def test_user_agent():
     assert session.headers['User-Agent'].startswith('chwrapper')
     assert 'python-requests' in session.headers['User-Agent']
 
+
 @responses.activate
 def test_custom_messages():
     """Check status code error messaging."""
@@ -119,7 +120,10 @@ def test_custom_ignore_codes_raised():
 def test_no_custom_messages():
     """Check status code, when custom_messages is empty."""
     url = 'https://api.companieshouse.gov.uk/search/companies'
-    responses.add(responses.GET, url, status=401)
+    responses.add(responses.GET,
+                  url,
+                  status=401,
+                  adding_headers={'X-Ratelimit-Remain': '1'})
 
     Service = chwrapper.Service()
     response = Service.get_session().get(url)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -7,20 +7,20 @@ import responses
 
 
 def test_Service_session():
-    """Get a session using an api"""
+    """Get a session using an api."""
     session = chwrapper.Service().get_session('pk.test')
     assert session.params.get('access_token') == 'pk.test'
 
 
 def test_Service_session_env():
-    """Get a session using the env's token"""
+    """Get a session using the env's token."""
     session = chwrapper.Service().get_session(
         env={'CompaniesHouseKey': 'pk.test_env'})
     assert session.params.get('access_token') == 'pk.test_env'
 
 
 def test_Service_session_os_environ(monkeypatch):
-    """Get a session using os.environ's token"""
+    """Get a session using os.environ's token."""
     monkeypatch.setenv('CompaniesHouseKey', 'pk.test_os_environ')
     session = chwrapper.Service().get_session()
     assert session.params.get('access_token') == 'pk.test_os_environ'
@@ -28,7 +28,7 @@ def test_Service_session_os_environ(monkeypatch):
 
 
 def test_Service_session_os_environ_caps(monkeypatch):
-    """Get a session using os.environ's token"""
+    """Get a session using os.environ's token."""
     monkeypatch.setenv('COMPANIES_HOUSE_KEY', 'pk.test_os_environ')
     session = chwrapper.Service().get_session()
     assert session.params.get('access_token') == 'pk.test_os_environ'
@@ -36,39 +36,39 @@ def test_Service_session_os_environ_caps(monkeypatch):
 
 
 def test_product_token():
-    """Get the product version"""
-    assert chwrapper.Service().product_token == 'chwrapper/{0}'.format(chwrapper.__version__)
+    """Get the product version."""
+    token = chwrapper.Service().product_token
+    assert token == 'chwrapper/{0}'.format(chwrapper.__version__)
 
 
 def test_user_agent():
-    """Check User-agent correctly assigned"""
+    """Check User-agent correctly assigned."""
     session = chwrapper.Service().get_session()
     assert session.headers['User-Agent'].startswith('chwrapper')
     assert 'python-requests' in session.headers['User-Agent']
 
-
 @responses.activate
 def test_custom_messages():
-    """Check status code error messaging"""
+    """Check status code error messaging."""
     fakeurl = 'https://example.com'
     responses.add(responses.GET,
                   fakeurl,
                   status=401,
                   adding_headers={'X-Ratelimit-Reset': '1460280499'})
 
-    Service = chwrapper.Service()
-    response = Service.get_session().get(fakeurl)
+    service = chwrapper.Service()
+    response = service.get_session().get(fakeurl)
 
     with pytest.raises(requests.exceptions.HTTPError) as exc:
-        assert Service.handle_http_error(response,
-                                         custom_messages={401: "error"})
+        service.handle_http_error(response,
+                                  custom_messages={401: "error"})
     try:
         assert exc.value.message == 'error'
     except AttributeError:
         assert "error" in exc.value.args[0]
 
     with pytest.raises(requests.exceptions.HTTPError) as exc:
-        assert Service.handle_http_error(response, raise_for_status=True)
+        assert service.handle_http_error(response, raise_for_status=True)
     try:
         assert "401" in exc.value.message
     except AttributeError:
@@ -76,8 +76,48 @@ def test_custom_messages():
 
 
 @responses.activate
+def test_custom_ignore_codes():
+    """Check custom codes are ignored correctly."""
+    fakeurl = 'https://example.com'
+    responses.add(responses.GET,
+                  fakeurl,
+                  status=429,
+                  adding_headers={'X-Ratelimit-Reset': '1460280499'})
+
+    service = chwrapper.Service()
+    response = service.get_session().get(fakeurl)
+
+    assert service._ignore_codes == []
+
+    service._ignore_codes.append(429)
+    assert 429 in service._ignore_codes
+
+    ret = service.handle_http_error(response, raise_for_status=True)
+    assert ret is None
+
+
+@responses.activate
+def test_custom_ignore_codes_raised():
+    """Check custom codes are ignored correctly."""
+    fakeurl = 'https://example.com'
+    responses.add(responses.GET,
+                  fakeurl,
+                  status=429,
+                  adding_headers={'X-Ratelimit-Reset': '1460280499'})
+
+    service = chwrapper.Service()
+    response = service.get_session().get(fakeurl)
+
+    assert service._ignore_codes == []
+    assert 429 not in service._ignore_codes
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        service.handle_http_error(response, raise_for_status=True)
+
+
+@responses.activate
 def test_no_custom_messages():
-    """Check status code, when custom_messages is empty"""
+    """Check status code, when custom_messages is empty."""
     url = 'https://api.companieshouse.gov.uk/search/companies'
     responses.add(responses.GET, url, status=401)
 
@@ -90,10 +130,12 @@ def test_no_custom_messages():
 
 
 class TestRateLimiting():
-    """the Service.rate_limit decorator"""
+    """The Service.rate_limit decorator."""
+
     s = chwrapper.Search(access_token="pk.test")
 
     def current_timestamp(self):
+        """UTC timestamp."""
         return int(datetime.timestamp(datetime.utcnow()))
 
     with open("tests/results.json") as results:
@@ -101,7 +143,7 @@ class TestRateLimiting():
 
     @responses.activate
     def test_rate_limit_renewal_missing(self):
-        """Test execurion continues when rate limit exceeded"""
+        """Test execution continues when rate limit exceeded"""
         responses.add(
             responses.GET,
             "https://api.companieshouse.gov.uk/search/companies?" +
@@ -117,7 +159,7 @@ class TestRateLimiting():
 
     @responses.activate
     def test_rate_limit_expired(self):
-        """Test error raised if rate limit exceeded and no reset time"""
+        """Test error raised if rate limit exceeded and no reset time."""
         responses.add(
             responses.GET,
             "https://api.companieshouse.gov.uk/search/companies?" +
@@ -133,7 +175,7 @@ class TestRateLimiting():
 
     @responses.activate
     def test_rate_limit_renewal(self):
-        """Test execution continues when rate limit exceeded"""
+        """Test execution continues when rate limit exceeded."""
         responses.add(
             responses.GET,
             "https://api.companieshouse.gov.uk/search/companies?" +
@@ -143,14 +185,15 @@ class TestRateLimiting():
             body=self.results,
             content_type="application/json",
             adding_headers={'X-Ratelimit-Remain': '0',
-                            'X-Ratelimit-Reset': '{}'.format(self.current_timestamp())})
+                            'X-Ratelimit-Reset': '{}'.format(
+                                self.current_timestamp())})
 
         res = self.s.search_companies("Python")
         assert res.status_code == 200
 
     @responses.activate
     def test_negative_time_raises_error_rate_limit(self):
-        """Test that negative time values raise a ValueError Exception"""
+        """Test that negative time values raise a ValueError Exception."""
         time_ten_seconds_ago = self.current_timestamp() - 10
         responses.add(
             responses.GET,
@@ -161,7 +204,8 @@ class TestRateLimiting():
             body=self.results,
             content_type="application/json",
             adding_headers={'X-Ratelimit-Remain': '0',
-                            'X-Ratelimit-Reset': '{}'.format(time_ten_seconds_ago)})
+                            'X-Ratelimit-Reset': '{}'.format(
+                                time_ten_seconds_ago)})
 
         with pytest.raises(ValueError):
             res = self.s.search_companies("Python")


### PR DESCRIPTION
This pull request removes the existing rate limit decorator and replaces it with a requests Transport Adaptor that implements the rate limiting algorithm. It also adds a way to specify what error codes to ignore. @cybojenix does this fulfil #23 enough for your use case?